### PR TITLE
Recipe for cloning a dataset to a different path

### DIFF
--- a/recipes/clone_dataset
+++ b/recipes/clone_dataset
@@ -1,15 +1,26 @@
+from pathlib import Path
+
+def translate_path(url, old_base, new_base):
+    table_url = Path(url.resolve(old_base))
+    try:
+        table_url = table_url.relative_to(new_base)
+    except ValueError:
+        pass
+    return table_url
+
 def clone_dataset_with_new_cognate_table(original_dataset, path):
     """Create a copy of original_dataset, with the same urls and a new CognateTable"""
     cognatetables = []
+    base_path = Path(original_dataset.base).absolute()
     for t, table in enumerate(original_dataset.tables):
         if table.common_props.get("dc:conformsTo", '').endswith('CognateTable'):
             cognatetables.insert(0, t)
         else:
             # Make table urls absolute
-            table.url = Link(str(table.url.resolve(table._parent.base)))
+            table.url = Link(str(translate_path(table.url, base_path, path))
             for key in table.tableSchema.foreignKeys:
                 key.reference.resource = Link(
-                    str(key.reference.resource.resolve(table._parent.base)))
+                    str(translate_path(key.reference.resource, base_path, path)))
     original_dataset.write_metadata(fname=path)
 
     new_dataset = pycldf.Wordlist.from_metadata(path)

--- a/recipes/clone_dataset
+++ b/recipes/clone_dataset
@@ -1,0 +1,29 @@
+def clone_dataset_with_new_cognate_table(original_dataset, path):
+    """Create a copy of original_dataset, with the same urls and a new CognateTable"""
+    cognatetables = []
+    for t, table in enumerate(original_dataset.tables):
+        if table.common_props.get("dc:conformsTo", '').endswith('CognateTable'):
+            cognatetables.insert(0, t)
+        else:
+            # Make table urls absolute
+            table.url = Link(str(table.url.resolve(table._parent.base)))
+            for key in table.tableSchema.foreignKeys:
+                key.reference.resource = Link(
+                    str(key.reference.resource.resolve(table._parent.base)))
+    original_dataset.write_metadata(fname=path)
+
+    new_dataset = pycldf.Wordlist.from_metadata(path)
+    # Delete existing cognate tables
+    for t in cognatetables:
+        del new_dataset.tables[t]
+
+    # Add a new, local cognate table
+    output_rows = []
+    new_dataset.add_component(
+        "CognateTable")
+    if new_dataset["CognateTable"].url.resolve(table._parent.base).exists():
+        new_dataset["CognateTable"].url = Link(Path(path).stem + '-cognates.csv')
+    new_dataset["CognateTable", "Form_ID"].datatype = new_dataset["FormTable", "id"].datatype
+
+    new_dataset.write_metadata(fname=path)
+


### PR DESCRIPTION
This function clones a dataset, giving it a new metadata file but keeping the tables intact.

In order to show the use of this functionality, it also adds/replaces the CognateTable with a new one.

I mostly submit this as a pull-request because 
 1. I think this is generally useful functionality, and the updating of URLs is less trivial than I thought, and
 2. I'm still not sure I did it correctly, so I would like feedback how to make it better.